### PR TITLE
List and migrate

### DIFF
--- a/backend/course-parser/Cargo.lock
+++ b/backend/course-parser/Cargo.lock
@@ -6,8 +6,13 @@ version = 3
 name = "course-parser"
 version = "0.1.0"
 dependencies = [
+ "storage_manager",
  "tl",
 ]
+
+[[package]]
+name = "storage_manager"
+version = "0.1.0"
 
 [[package]]
 name = "tl"

--- a/backend/course-parser/Cargo.toml
+++ b/backend/course-parser/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 tl = "0.7.7"
+storage_manager = { path = "../rust/storage_manager" }


### PR DESCRIPTION
Added list functionality to the storage, such that we can list filenames inside the directory and subdirectories. Also migrated the parser to use the storage trait instead of the previous implementation, no performance loss, good readability gain <3